### PR TITLE
SHARMAN-4152 : XCONF and Log upload is not working in MAPT devices

### DIFF
--- a/scripts/xb6_firmwareDwnld.sh
+++ b/scripts/xb6_firmwareDwnld.sh
@@ -43,6 +43,7 @@ then
     source /lib/rdk/stateRedRecoveryUtils.sh
 fi
 
+LANIPV6Support=`sysevent get LANIPv6GUASupport`
 
 echo_t()
 {
@@ -496,7 +497,16 @@ getFirmwareUpgDetail()
     # respose or the URL received
     xconf_retry_count=0
     retry_flag=1
-    isIPv6=`ifconfig $interface | grep inet6 | grep -i 'Global'`
+    if [ "x$BOX_TYPE" = "xHUB4" ] || [ "x$BOX_TYPE" = "xSR300" ] || [ "x$BOX_TYPE" = "xSR213" ] || [ "$LANIPV6Support" == "true" ]; then
+       CURRENT_WAN_IPV6_STATUS=`sysevent get ipv6_connection_state`
+       if [ "xup" = "x$CURRENT_WAN_IPV6_STATUS" ] ; then
+             isIPv6=`ifconfig $HUB4_IPV6_INTERFACE | grep Global |  awk '/inet6/{print $3}' | cut -d '/' -f1 | head -n1`
+       else
+             isIPv6=`ifconfig $interface | grep inet6 | grep -i 'Global'`
+       fi
+    else
+       isIPv6=`ifconfig $interface | grep inet6 | grep -i 'Global'`
+    fi
     # Set the XCONF server url read from /tmp/Xconf 
     # Determine the env from $type
 
@@ -1341,8 +1351,16 @@ echo_t "XCONF SCRIPT : Values written to /tmp/Xconf are URL=$url" >> $XCONF_LOG_
 
 # Check if the WAN interface has an ip address, if not , wait for it to receive one
 estbIp=`ifconfig $interface | grep "inet addr" | tr -s " " | cut -d ":" -f2 | cut -d " " -f1`
-
-estbIp6=`ifconfig $interface | grep "inet6 addr" | grep "Global" | tr -s " " | cut -d ":" -f2- | cut -d "/" -f1 | tr -d " "`
+if [ "x$BOX_TYPE" = "xHUB4" ] || [ "x$BOX_TYPE" = "xSR300" ] || [ "x$BOX_TYPE" = "xSR213" ] || [ "$LANIPV6Support" == "true" ]; then
+   CURRENT_WAN_IPV6_STATUS=`sysevent get ipv6_connection_state`
+   if [ "xup" = "x$CURRENT_WAN_IPV6_STATUS" ] ; then
+         estbIp6=`ifconfig $HUB4_IPV6_INTERFACE | grep Global |  awk '/inet6/{print $3}' | cut -d '/' -f1 | head -n1`
+   else
+      estbIp6=`ifconfig $interface | grep "inet6 addr" | grep "Global" | tr -s " " | cut -d ":" -f2- | cut -d "/" -f1 | tr -d " "`
+   fi
+else
+   estbIp6=`ifconfig $interface | grep "inet6 addr" | grep "Global" | tr -s " " | cut -d ":" -f2- | cut -d "/" -f1 | tr -d " "`
+fi
 echo_t "[ $(date) ] XCONF SCRIPT - Check if the WAN interface has an ip address" >> $XCONF_LOG_FILE
 
 while [ "$estbIp" = "" ] && [ "$estbIp6" = "" ]
@@ -1351,7 +1369,16 @@ do
     sleep 5
     interface=$(getWanInterfaceName)
     estbIp=`ifconfig $interface | grep "inet addr" | tr -s " " | cut -d ":" -f2 | cut -d " " -f1`
-    estbIp6=`ifconfig $interface | grep "inet6 addr" | grep "Global" | tr -s " " | cut -d ":" -f2- | cut -d "/" -f1 | tr -d " "`
+    if [ "x$BOX_TYPE" = "xHUB4" ] || [ "x$BOX_TYPE" = "xSR300" ] || [ "x$BOX_TYPE" = "xSR213" ] || [ "$LANIPV6Support" = "true" ]; then
+       CURRENT_WAN_IPV6_STATUS=`sysevent get ipv6_connection_state`
+       if [ "xup" = "x$CURRENT_WAN_IPV6_STATUS" ] ; then
+             estbIp6=`ifconfig $HUB4_IPV6_INTERFACE | grep Global |  awk '/inet6/{print $3}' | cut -d '/' -f1 | head -n1`
+       else
+          estbIp6=`ifconfig $interface | grep "inet6 addr" | grep "Global" | tr -s " " | cut -d ":" -f2- | cut -d "/" -f1 | tr -d " "`
+       fi
+    else
+       estbIp6=`ifconfig $interface | grep "inet6 addr" | grep "Global" | tr -s " " | cut -d ":" -f2- | cut -d "/" -f1 | tr -d " "`
+    fi
     echo_t "XCONF SCRIPT : Sleeping for an ipv4 or an ipv6 address on the $interface interface "
 done
 


### PR DESCRIPTION
Reason for change: For MAPT Sky device, if the brlan0 has IPv6 Global address, it will proceed for the xconf upgrade

Test Procedure:

Risks: Low

Priority:P1