### PR TITLE
RDKB-64798: Disable AutoExcludedURL override when Direct CDN is enabled

### DIFF
--- a/scripts/cbr_firmwareDwnld.sh
+++ b/scripts/cbr_firmwareDwnld.sh
@@ -1261,7 +1261,7 @@ if [ -f /nvram/swupdate.conf ]; then
 else
   # RFC override should work only for non-production build
   url_override=`syscfg get AutoExcludedURL`
-  if [ "$url_override" ] && [ "$type" != "PROD" ] && [ $BUILD_TYPE != "prod" ] ; then
+  if [ "$url_override" ] && [ "$type" != "PROD" ] && [ $BUILD_TYPE != "prod" ] && [ "$direct_CDN" != "true" ]; then
      url=$url_override
   fi
 fi

--- a/scripts/xb6_firmwareDwnld.sh
+++ b/scripts/xb6_firmwareDwnld.sh
@@ -1324,10 +1324,13 @@ if [ "$type" != "PROD" ] && [ "$type" != "prod" ]; then
     else
         # RFC override should work only for non-production build
         url_override=`syscfg get AutoExcludedURL`
-        if [ "$url_override" ] ; then
-           url=$url_override
-           xconf_url=$url
-           CDL_SERVER_OVERRIDE=1
+        # Set CDL_SERVER_OVERRIDE only for non-direct-CDN flow
+        if [ "$url_override" ] && [ "$direct_CDN" != "true" ]; then
+            url=$url_override
+            xconf_url=$url
+            CDL_SERVER_OVERRIDE=1
+        else
+            echo "XCONF SCRIPT : AutoExcludedURL override skipped because Direct CDN is enabled." >> $XCONF_LOG_FILE
         fi
     fi
 else


### PR DESCRIPTION
Reason for change: Prevent AutoExcludedURL from overriding the firmware URL when Direct CDN is enabled.
Test Procedure: As mentioned in the ticket
Risks: Low
Priority: P1

Signed-off-by: plaksh175_comcast <PiramanayagamMoneka_Lakshmi@comcast.com>