### PR TITLE
RDKB-66076: Firmware upgrade is failing through XCONF

### DIFF
--- a/scripts/cbr_firmwareDwnld.sh
+++ b/scripts/cbr_firmwareDwnld.sh
@@ -781,6 +781,7 @@ getFirmwareUpgDetail()
                     fi
 		fi
 
+        fi
 
         # If a response code of 404 was received, exit
         elif [[ $HTTP_RESPONSE_CODE -eq 404 ]]; then


### PR DESCRIPTION
Reason for change: There is a missing closure for if condition which causes the failure.
Test Procedure: Firware upgrade using XCONF should be successful.
Risks:low
Priority: P1